### PR TITLE
Add the @avaialble directive to restrict the code being able to execute only under iOS 13 and above and add Authorization support.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
         .library(name: "LoggingELK", targets: ["LoggingELK"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-log.git", .upToNextMinor(from: "1.4.0")),
-        .package(url: "https://github.com/swift-server/async-http-client.git", .upToNextMinor(from: "1.5.0"))
+        .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.4.0")),
+        .package(url: "https://github.com/swift-server/async-http-client.git", .upToNextMajor(from: "1.5.0"))
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
         .library(name: "LoggingELK", targets: ["LoggingELK"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.4.0")),
-        .package(url: "https://github.com/swift-server/async-http-client.git", .upToNextMajor(from: "1.5.0"))
+        .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.6.2")),
+        .package(url: "https://github.com/swift-server/async-http-client.git", .upToNextMajor(from: "1.25.2"))
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "swift-log-elk",
     platforms: [
         .macOS(.v10_15),
-        .iOS(.v13)
+        .iOS(.v15)
     ],
     products: [
         .library(name: "LoggingELK", targets: ["LoggingELK"])

--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
         .library(name: "LoggingELK", targets: ["LoggingELK"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-log.git", exact: "1.6.2"),
-        .package(url: "https://github.com/swift-server/async-http-client.git", exact: "1.25.2")
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.6.4"),
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.29.0")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.9
 
 import PackageDescription
 
@@ -13,8 +13,8 @@ let package = Package(
         .library(name: "LoggingELK", targets: ["LoggingELK"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-log.git", .exact("1.6.2")),
-        .package(url: "https://github.com/swift-server/async-http-client.git", .exact("1.25.2"))
+        .package(url: "https://github.com/apple/swift-log.git", exact: "1.6.2"),
+        .package(url: "https://github.com/swift-server/async-http-client.git", exact: "1.25.2")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
         .library(name: "LoggingELK", targets: ["LoggingELK"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.6.2")),
-        .package(url: "https://github.com/swift-server/async-http-client.git", .upToNextMajor(from: "1.25.2"))
+        .package(url: "https://github.com/apple/swift-log.git", .exact("1.6.2")),
+        .package(url: "https://github.com/swift-server/async-http-client.git", .exact("1.25.2"))
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # LoggingELK
+# DEPRECATED. Starting from 8.0.0 release of https://github.com/servicetrade/servicetrade-app-ios this repo and related https://github.com/servicetrade/logger are not used. Should be kept for a while in case we need to compile old version. Don't delete before 2027.
 
 ![Swift5.4+](https://img.shields.io/badge/Swift-5.4%2B-orange.svg?style=flat)
 [![release](https://img.shields.io/github/v/release/Apodini/swift-log-elk.svg?include_prereleases&color=blue)](https://github.com/Apodini/swift-log-elk/releases)

--- a/Sources/LoggingELK/LogstashLogHandler+HTTPFormatting.swift
+++ b/Sources/LoggingELK/LogstashLogHandler+HTTPFormatting.swift
@@ -54,6 +54,10 @@ extension LogstashLogHandler {
         }
 
         // Set headers that always stay consistent over all requests
+        if let authorization = self.authorization {
+            httpRequest.headers.add(name: "Authorization", value: authorization.value)
+        }
+        
         httpRequest.headers.add(name: "Content-Type", value: "application/json")
         httpRequest.headers.add(name: "Accept", value: "application/json")
         // Keep-alive header to keep the connection open

--- a/Sources/LoggingELK/LogstashLogHandler.swift
+++ b/Sources/LoggingELK/LogstashLogHandler.swift
@@ -91,6 +91,7 @@ public struct LogstashLogHandler: LogHandler {
     public static func setup(hostname: String,
                              port: Int,
                              useHTTPS: Bool = false,
+                             authorization: Authorizable? = nil,
                              eventLoopGroup: EventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: (System.coreCount != 1) ? System.coreCount / 2 : 1),
                              backgroundActivityLogger: Logger = Logger(label: "backgroundActivity-logstashHandler"),
                              uploadInterval: TimeAmount = TimeAmount.seconds(3),
@@ -103,6 +104,7 @@ public struct LogstashLogHandler: LogHandler {
         Self.hostname = hostname
         Self.port = port
         Self.useHTTPS = useHTTPS
+        Self.authorization = authorization
         Self.eventLoopGroup = eventLoopGroup
         Self.backgroundActivityLogger = backgroundActivityLogger
         Self.uploadInterval = uploadInterval

--- a/Sources/LoggingELK/LogstashLogHandler.swift
+++ b/Sources/LoggingELK/LogstashLogHandler.swift
@@ -13,6 +13,7 @@ import AsyncHTTPClient
 
 /// `LogstashLogHandler` is a simple implementation of `LogHandler` for directing
 /// `Logger` output to Logstash via HTTP requests
+@available(iOS 13.0, *)
 public struct LogstashLogHandler: LogHandler {
     /// The label of the `LogHandler`
     let label: String

--- a/Sources/LoggingELK/LogstashLogHandler.swift
+++ b/Sources/LoggingELK/LogstashLogHandler.swift
@@ -22,6 +22,8 @@ public struct LogstashLogHandler: LogHandler {
     static var port: Int?
     /// Specifies if the HTTP connection to Logstash should be encrypted via TLS (so HTTPS instead of HTTP)
     static var useHTTPS: Bool?
+    /// Specifies  the authorization schema for the HTTP request
+    static var authorization: Authorizable?
     /// The `EventLoopGroup` which is used to create the `HTTPClient`
     static var eventLoopGroup: EventLoopGroup?
     /// Used to log background activity of the `LogstashLogHandler` and `HTTPClient`

--- a/Sources/LoggingELK/Utils/Authorization.swift
+++ b/Sources/LoggingELK/Utils/Authorization.swift
@@ -1,0 +1,45 @@
+//
+//  Authentication.swift
+//  
+//
+//  Created by Oleg Bragin on 09.11.2022.
+//
+
+import Foundation
+
+/// Describes the property which should be used to set the authorization header
+/// to access a remote resource
+public protocol Authorizable {
+    /// Should return authorization header value.
+    var value: String { get }
+}
+
+/// Defines the most commonly used authroization type names: Basic and Bearer
+/// Basically define the first part of overall Authorization header value, e.g.:
+/// `Basic <token>`, etc.
+public enum AuthorizationType: String {
+    case basic
+    case bearer
+    
+    public var name: String {
+        switch self {
+        case .basic:
+            return "Basic"
+        case .bearer:
+            return "Bearer"
+        }
+    }
+}
+
+/// Defines the default way of providing the authorization header to caller
+public struct Authorization: Authorizable {
+    /// Type of authorization
+    let type: AuthorizationType
+    /// Token string, which should generated outside
+    let token: String
+    
+    /// A string concatenated from type name and token itself for authroization header field
+    public var value: String {
+        return "\(type.name) \(token)"
+    }
+}

--- a/Sources/LoggingELK/Utils/Authorization.swift
+++ b/Sources/LoggingELK/Utils/Authorization.swift
@@ -38,6 +38,16 @@ public struct Authorization: Authorizable {
     /// Token string, which should generated outside
     let token: String
     
+    /// Initialize a new authroization structure to provide access to
+    /// some protected url
+    /// - Parameters:
+    ///   - type: authorization type, e.g. `basic`, `bearer`, ...
+    ///   - token: generated authorization token
+    public init(type: AuthorizationType, token: String) {
+        self.type = type
+        self.token = token
+    }
+    
     /// A string concatenated from type name and token itself for authroization header field
     public var value: String {
         return "\(type.name) \(token)"


### PR DESCRIPTION
# *Name of the PR*
Enhance restriction of supported iOS version 13 and above in code. And allow proving the http requests with authorisation header.

## :recycle: Current situation
The package lacks the @avaialble directive and doesn't built under Xcode 14 and authorisation support

## :bulb: Proposed solution
Added the @available(iOS 13, *) for the whole LogstashLogHandler struct.  
Added Authorizable protocol and a default structure implementing it, so that http request for uploading the logs can use authorisation.

### Testing
Test for @avaialble directive were not changed, since it was only a compile time issue.
Test for Authorisation support are not added, since it requires more work, because current tests are not emulating the upload process itself. Tests for that are coming soon.

### Reviewer Nudging
From the beginning.
